### PR TITLE
UmbrellaGrid Reset bug fix

### DIFF
--- a/AspNetCore/src/Umbrella.AspNetCore.Blazor/Components/Grid/UmbrellaGrid.razor.cs
+++ b/AspNetCore/src/Umbrella.AspNetCore.Blazor/Components/Grid/UmbrellaGrid.razor.cs
@@ -778,10 +778,8 @@ public partial class UmbrellaGrid<TItem> : IUmbrellaGrid<TItem>, IAsyncDisposabl
 					string[] queryStringKeysToRemove = [SortByQueryStringParamKey, SortDirectionQueryStringParamKey, FiltersQueryStringParamKey, PageNumberQueryStringParamKey];
 
 					var uri = new Uri(url);
-					Uri? newUri = uri.GetUriWithoutQueryStringParameters(queryStringKeysToRemove);
-
-					if (newUri is not null)
-						url = newUri.AbsoluteUri;
+					uri = uri.GetUriWithoutQueryStringParameters(queryStringKeysToRemove);
+					url = uri.AbsoluteUri;
 
 					Logger.WriteDebug(message: "Url after reset.");
 					if (Logger.IsEnabled(LogLevel.Debug))

--- a/AspNetCore/src/Umbrella.AspNetCore.Blazor/Components/Grid/UmbrellaGrid.razor.cs
+++ b/AspNetCore/src/Umbrella.AspNetCore.Blazor/Components/Grid/UmbrellaGrid.razor.cs
@@ -783,7 +783,7 @@ public partial class UmbrellaGrid<TItem> : IUmbrellaGrid<TItem>, IAsyncDisposabl
 					Uri? newUri = uri.GetUriWithoutQueryStringParameters(queryStringKeysToRemove);
 
 					if (newUri is not null)
-						url = uri.AbsoluteUri;
+						url = newUri.AbsoluteUri;
 
 					Logger.WriteDebug(message: "Url after reset.");
 					if (Logger.IsEnabled(LogLevel.Debug))
@@ -799,81 +799,6 @@ public partial class UmbrellaGrid<TItem> : IUmbrellaGrid<TItem>, IAsyncDisposabl
 
 					Navigation.NavigateTo(url);
 				}
-
-				//Uri GetUriWithoutQueryStringParameters(Uri uri, params string[] keysToRemove)
-				//{
-				//	Logger.WriteDebug(message: "***keysToRemove***");
-				//	if (Logger.IsEnabled(LogLevel.Debug))
-				//		Logger.WriteDebug(new { keysToRemove });
-
-				//	var query = QueryHelpers.ParseQuery(uri.Query);
-
-				//	foreach((string queryKey, StringValues queryValue) in query)
-				//	{
-				//		Logger.WriteDebug(message: "$$$$$$$$$");
-				//		Logger.WriteDebug(new { queryKey, queryValue });
-				//	}
-
-				//	Logger.WriteDebug(message: "***Query***");
-				//	if (Logger.IsEnabled(LogLevel.Debug))
-				//		Logger.WriteDebug(new { query });
-
-				//	foreach (string key in keysToRemove)
-				//	{
-				//		query.Remove(key);
-
-				//		Logger.WriteDebug(message: "***foreach key***");
-				//		if (Logger.IsEnabled(LogLevel.Debug))
-				//			Logger.WriteDebug(new { key, keysToRemove });
-				//	}
-
-				//	Logger.WriteDebug(message: "***Query2***");
-				//	if (Logger.IsEnabled(LogLevel.Debug))
-				//		Logger.WriteDebug(new { query });
-
-				//	string queryStr = "";
-
-				//	foreach(var item in query)
-				//	{
-
-				//	}
-
-				//	var uriBuilder = new UriBuilder(uri)
-				//	{
-				//		Query = query.Count > 0 ? QueryHelpers. : string.Empty
-				//	};
-
-				//	Logger.WriteDebug(message: "***UriBuilder***");
-				//	if (Logger.IsEnabled(LogLevel.Debug))
-				//		Logger.WriteDebug(new { uriBuilder });
-
-				//	return uriBuilder.Uri;
-				//}
-
-				//Uri GetUriWithoutQueryStringParameters(Uri uri, string[] keysToRemove)
-				//{
-				//	// Parse the query string into a name-value collection
-				//	NameValueCollection queryParameters = HttpUtility.ParseQueryString(uri.Query);
-
-				//	// Remove the specified keys from the collection
-				//	foreach (string key in keysToRemove)
-				//	{
-				//		queryParameters.Remove(key);
-				//	}
-
-				//	// Rebuild the query string from the remaining parameters
-				//	string newQueryString = string.Join("&", queryParameters.AllKeys
-				//		.Where(key => !string.IsNullOrEmpty(key))
-				//		.Select(key => $"{HttpUtility.UrlEncode(key)}={HttpUtility.UrlEncode(queryParameters[key])}"));
-
-				//	// Reconstruct the URI without the removed query parameters
-				//	var uriBuilder = new UriBuilder(uri)
-				//	{
-				//		Query = newQueryString
-				//	};
-
-				//	return uriBuilder.Uri;
-				//}
 			}
 
 			UmbrellaGridDataResponse<TItem>? response = await OnDataRequestedAsync(new UmbrellaGridDataRequest(PageNumber, PageSize, EnsureCollection(lstSorters), EnsureCollection(lstFilters)), _cts.Token);

--- a/AspNetCore/src/Umbrella.AspNetCore.Blazor/Components/Grid/UmbrellaGrid.razor.cs
+++ b/AspNetCore/src/Umbrella.AspNetCore.Blazor/Components/Grid/UmbrellaGrid.razor.cs
@@ -630,6 +630,8 @@ public partial class UmbrellaGrid<TItem> : IUmbrellaGrid<TItem>, IAsyncDisposabl
 
 	private async Task UpdateGridAsync(QueryStringStateUpdateMode queryStringStateUpdateMode, int? pageNumber = null, int? pageSize = null)
 	{
+		Logger.WriteDebug(message: "***********************************************************Updating Grid***************************************************");
+
 		PageNumber = pageNumber ?? 1;
 
 		if (pageSize.HasValue)
@@ -774,13 +776,18 @@ public partial class UmbrellaGrid<TItem> : IUmbrellaGrid<TItem>, IAsyncDisposabl
 				}
 				else if (queryStringStateUpdateMode is QueryStringStateUpdateMode.Reset)
 				{
-					url = new Uri(url).GetComponents(UriComponents.Path, UriFormat.Unescaped);
+					//All Grid query string values such as filter are removed, we need to ensure any changes to the page size are preserved.
+					string[] queryStringKeysToRemove = [SortByQueryStringParamKey, SortDirectionQueryStringParamKey, FiltersQueryStringParamKey, PageNumberQueryStringParamKey];
 
-					// We need to ensure any changes to the page size are preserved.
-					url = Navigation.GetUriWithQueryParameters(url, new Dictionary<string, object?>
-					{
-						[PageSizeQueryStringParamKey] = PageSize != UmbrellaPaginationDefaults.PageSize ? PageSize : null
-					});
+					var uri = new Uri(url);
+					Uri? newUri = uri.GetUriWithoutQueryStringParameters(queryStringKeysToRemove);
+
+					if (newUri is not null)
+						url = uri.AbsoluteUri;
+
+					Logger.WriteDebug(message: "Url after reset.");
+					if (Logger.IsEnabled(LogLevel.Debug))
+						Logger.WriteDebug(new { url });
 				}
 
 				if (url != Navigation.Uri)
@@ -792,6 +799,81 @@ public partial class UmbrellaGrid<TItem> : IUmbrellaGrid<TItem>, IAsyncDisposabl
 
 					Navigation.NavigateTo(url);
 				}
+
+				//Uri GetUriWithoutQueryStringParameters(Uri uri, params string[] keysToRemove)
+				//{
+				//	Logger.WriteDebug(message: "***keysToRemove***");
+				//	if (Logger.IsEnabled(LogLevel.Debug))
+				//		Logger.WriteDebug(new { keysToRemove });
+
+				//	var query = QueryHelpers.ParseQuery(uri.Query);
+
+				//	foreach((string queryKey, StringValues queryValue) in query)
+				//	{
+				//		Logger.WriteDebug(message: "$$$$$$$$$");
+				//		Logger.WriteDebug(new { queryKey, queryValue });
+				//	}
+
+				//	Logger.WriteDebug(message: "***Query***");
+				//	if (Logger.IsEnabled(LogLevel.Debug))
+				//		Logger.WriteDebug(new { query });
+
+				//	foreach (string key in keysToRemove)
+				//	{
+				//		query.Remove(key);
+
+				//		Logger.WriteDebug(message: "***foreach key***");
+				//		if (Logger.IsEnabled(LogLevel.Debug))
+				//			Logger.WriteDebug(new { key, keysToRemove });
+				//	}
+
+				//	Logger.WriteDebug(message: "***Query2***");
+				//	if (Logger.IsEnabled(LogLevel.Debug))
+				//		Logger.WriteDebug(new { query });
+
+				//	string queryStr = "";
+
+				//	foreach(var item in query)
+				//	{
+
+				//	}
+
+				//	var uriBuilder = new UriBuilder(uri)
+				//	{
+				//		Query = query.Count > 0 ? QueryHelpers. : string.Empty
+				//	};
+
+				//	Logger.WriteDebug(message: "***UriBuilder***");
+				//	if (Logger.IsEnabled(LogLevel.Debug))
+				//		Logger.WriteDebug(new { uriBuilder });
+
+				//	return uriBuilder.Uri;
+				//}
+
+				//Uri GetUriWithoutQueryStringParameters(Uri uri, string[] keysToRemove)
+				//{
+				//	// Parse the query string into a name-value collection
+				//	NameValueCollection queryParameters = HttpUtility.ParseQueryString(uri.Query);
+
+				//	// Remove the specified keys from the collection
+				//	foreach (string key in keysToRemove)
+				//	{
+				//		queryParameters.Remove(key);
+				//	}
+
+				//	// Rebuild the query string from the remaining parameters
+				//	string newQueryString = string.Join("&", queryParameters.AllKeys
+				//		.Where(key => !string.IsNullOrEmpty(key))
+				//		.Select(key => $"{HttpUtility.UrlEncode(key)}={HttpUtility.UrlEncode(queryParameters[key])}"));
+
+				//	// Reconstruct the URI without the removed query parameters
+				//	var uriBuilder = new UriBuilder(uri)
+				//	{
+				//		Query = newQueryString
+				//	};
+
+				//	return uriBuilder.Uri;
+				//}
 			}
 
 			UmbrellaGridDataResponse<TItem>? response = await OnDataRequestedAsync(new UmbrellaGridDataRequest(PageNumber, PageSize, EnsureCollection(lstSorters), EnsureCollection(lstFilters)), _cts.Token);

--- a/AspNetCore/src/Umbrella.AspNetCore.Blazor/Components/Grid/UmbrellaGrid.razor.cs
+++ b/AspNetCore/src/Umbrella.AspNetCore.Blazor/Components/Grid/UmbrellaGrid.razor.cs
@@ -630,8 +630,6 @@ public partial class UmbrellaGrid<TItem> : IUmbrellaGrid<TItem>, IAsyncDisposabl
 
 	private async Task UpdateGridAsync(QueryStringStateUpdateMode queryStringStateUpdateMode, int? pageNumber = null, int? pageSize = null)
 	{
-		Logger.WriteDebug(message: "***********************************************************Updating Grid***************************************************");
-
 		PageNumber = pageNumber ?? 1;
 
 		if (pageSize.HasValue)

--- a/Core/src/Umbrella.Utilities/Extensions/UriExtensions.cs
+++ b/Core/src/Umbrella.Utilities/Extensions/UriExtensions.cs
@@ -83,7 +83,7 @@ public static class UriExtensions
 
         // Rebuild the query string from the remaining parameters
         string newQueryString = string.Join("&", queryParameters.Keys
-            .Where(key => !string.IsNullOrEmpty(key))
+            .Where(key => !string.IsNullOrEmpty(key) && !string.IsNullOrEmpty(queryParameters[key]))
             .Select(key => $"{Uri.EscapeDataString(key)}={Uri.EscapeDataString(queryParameters[key]!)}"));
 
         // Reconstruct the URI without the removed query parameters

--- a/Core/src/Umbrella.Utilities/Extensions/UriExtensions.cs
+++ b/Core/src/Umbrella.Utilities/Extensions/UriExtensions.cs
@@ -3,61 +3,95 @@
 namespace Umbrella.Utilities.Extensions;
 
 /// <summary>
-/// Extension methods that operation on <see cref="Uri"/> instances.
+/// Extension methods that operate on <see cref="Uri"/> instances.
 /// </summary>
 public static class UriExtensions
 {
-	/// <summary>
-	/// Tries the get query string value from the <see cref="Uri.Query"/> property.
-	/// </summary>
-	/// <typeparam name="T">The type of the value being read from the querystring.</typeparam>
-	/// <param name="uri">The URI</param>
-	/// <param name="key">The key of the value being read from the querystring.</param>
-	/// <returns>A tuple containing fields indicating success together with any value.</returns>
-	/// <exception cref="NotSupportedException">Query Paramaters of type {typeof(T).Name} cannot be converted.</exception>
-	public static (bool success, T value) TryGetQueryStringValue<T>(this Uri uri, string key)
-	{
-		if (QueryHelpers.ParseQuery(uri.Query).TryGetValue(key, out var valueFromQueryString))
-		{
-			if (typeof(T) == typeof(int) && int.TryParse(valueFromQueryString, out int valueAsInt))
-			{
-				var value = (T)(object)valueAsInt;
-				return (true, value);
-			}
+    /// <summary>
+    /// Tries to get the query string value from the <see cref="Uri.Query"/> property.
+    /// </summary>
+    /// <typeparam name="T">The type of the value being read from the query string.</typeparam>
+    /// <param name="uri">The URI.</param>
+    /// <param name="key">The key of the value being read from the query string.</param>
+    /// <returns>A tuple containing fields indicating success together with any value.</returns>
+    /// <exception cref="NotSupportedException">Query parameters of type {typeof(T).Name} cannot be converted.</exception>
+    public static (bool success, T value) TryGetQueryStringValue<T>(this Uri uri, string key)
+    {
+        if (QueryHelpers.ParseQuery(uri.Query).TryGetValue(key, out var valueFromQueryString))
+        {
+            if (typeof(T) == typeof(int) && int.TryParse(valueFromQueryString, out int valueAsInt))
+            {
+                var value = (T)(object)valueAsInt;
+                return (true, value);
+            }
 
-			if (typeof(T) == typeof(string))
-			{
-				var value = (T)(object)valueFromQueryString.ToString();
-				return (true, value);
-			}
+            if (typeof(T) == typeof(string))
+            {
+                var value = (T)(object)valueFromQueryString.ToString();
+                return (true, value);
+            }
 
-			if (typeof(T) == typeof(double) && double.TryParse(valueFromQueryString, out double valueAsDouble))
-			{
-				var value = (T)(object)valueAsDouble;
-				return (true, value);
-			}
+            if (typeof(T) == typeof(double) && double.TryParse(valueFromQueryString, out double valueAsDouble))
+            {
+                var value = (T)(object)valueAsDouble;
+                return (true, value);
+            }
 
-			if (typeof(T) == typeof(bool) && bool.TryParse(valueFromQueryString, out bool valueAsBool))
-			{
-				var value = (T)(object)valueAsBool;
-				return (true, value);
-			}
+            if (typeof(T) == typeof(bool) && bool.TryParse(valueFromQueryString, out bool valueAsBool))
+            {
+                var value = (T)(object)valueAsBool;
+                return (true, value);
+            }
 
-			throw new NotSupportedException($"Query Parameters of type {typeof(T).Name} cannot be converted.");
-		}
+            throw new NotSupportedException($"Query parameters of type {typeof(T).Name} cannot be converted.");
+        }
 
-		return default;
-	}
+        return default;
+    }
 
-	/// <summary>
-	/// Tries the get query string enum value from the <see cref="Uri.Query"/> property.
-	/// </summary>
-	/// <typeparam name="T">The type of the enum value being read from the querystring.</typeparam>
-	/// <param name="uri">The URI</param>
-	/// <param name="key">The key of the value being read from the querystring..</param>
-	/// <returns>A tuple containing fields indicating success together with any enum value.</returns>
-	public static (bool success, T value) TryGetQueryStringEnumValue<T>(this Uri uri, string key)
-		where T : struct, Enum => QueryHelpers.ParseQuery(uri.Query).TryGetValue(key, out var valueFromQueryString) && Enum.TryParse<T>(valueFromQueryString, true, out var valueAsEnum)
-			? (true, valueAsEnum)
-			: default;
+    /// <summary>
+    /// Tries to get the query string enum value from the <see cref="Uri.Query"/> property.
+    /// </summary>
+    /// <typeparam name="T">The type of the enum value being read from the query string.</typeparam>
+    /// <param name="uri">The URI.</param>
+    /// <param name="key">The key of the value being read from the query string.</param>
+    /// <returns>A tuple containing fields indicating success together with any enum value.</returns>
+    public static (bool success, T value) TryGetQueryStringEnumValue<T>(this Uri uri, string key)
+        where T : struct, Enum => QueryHelpers.ParseQuery(uri.Query).TryGetValue(key, out var valueFromQueryString) && Enum.TryParse<T>(valueFromQueryString, true, out var valueAsEnum)
+            ? (true, valueAsEnum)
+            : default;
+
+    /// <summary>
+    /// Strips a Uri of the specified query string parameters.
+    /// </summary>
+    /// <param name="uri">The URI.</param>
+    /// <param name="keysToRemove">The keys of the query string parameters to remove.</param>
+    /// <returns>Returns the input <see cref="Uri"/> with the specified query string parameters removed.</returns>
+    public static Uri? GetUriWithoutQueryStringParameters(this Uri uri, string[] keysToRemove)
+    {
+        if (uri is null || keysToRemove is null || keysToRemove.Length is 0)
+            return null;
+
+        // Parse the query string into a name-value collection
+        var queryParameters = QueryHelpers.ParseQuery(uri.Query);
+
+        // Remove the specified keys from the collection
+        foreach (string key in keysToRemove)
+        {
+            queryParameters.Remove(key);
+        }
+
+        // Rebuild the query string from the remaining parameters
+        string newQueryString = string.Join("&", queryParameters.Keys
+            .Where(key => !string.IsNullOrEmpty(key))
+            .Select(key => $"{Uri.EscapeDataString(key)}={Uri.EscapeDataString(queryParameters[key]!)}"));
+
+        // Reconstruct the URI without the removed query parameters
+        var uriBuilder = new UriBuilder(uri)
+        {
+            Query = newQueryString
+        };
+
+        return uriBuilder.Uri;
+    }
 }

--- a/Core/src/Umbrella.Utilities/Extensions/UriExtensions.cs
+++ b/Core/src/Umbrella.Utilities/Extensions/UriExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Umbrella.Utilities.Http;
+﻿using CommunityToolkit.Diagnostics;
+using Umbrella.Utilities.Http;
 
 namespace Umbrella.Utilities.Extensions;
 
@@ -67,10 +68,10 @@ public static class UriExtensions
     /// <param name="uri">The URI.</param>
     /// <param name="keysToRemove">The keys of the query string parameters to remove.</param>
     /// <returns>Returns the input <see cref="Uri"/> with the specified query string parameters removed.</returns>
-    public static Uri? GetUriWithoutQueryStringParameters(this Uri uri, string[] keysToRemove)
+    public static Uri GetUriWithoutQueryStringParameters(this Uri uri, string[] keysToRemove)
     {
-        if (uri is null || keysToRemove is null || keysToRemove.Length is 0)
-            return null;
+		Guard.IsNotNull(uri, nameof(uri));
+		Guard.IsNotNull(keysToRemove, nameof(keysToRemove));
 
         // Parse the query string into a name-value collection
         var queryParameters = QueryHelpers.ParseQuery(uri.Query);

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>6.0.0-preview-0304</Version>
+		<Version>6.0.0-preview-0305</Version>
 
 		<Nullable>enable</Nullable>
 		<WarningsAsErrors>nullable</WarningsAsErrors>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>6.0.0-preview-0303</Version>
+		<Version>6.0.0-preview-0304</Version>
 
 		<Nullable>enable</Nullable>
 		<WarningsAsErrors>nullable</WarningsAsErrors>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>6.0.0-preview-0284</Version>
+		<Version>6.0.0-preview-0301</Version>
 
 		<Nullable>enable</Nullable>
 		<WarningsAsErrors>nullable</WarningsAsErrors>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>6.0.0-preview-0301</Version>
+		<Version>6.0.0-preview-0303</Version>
 
 		<Nullable>enable</Nullable>
 		<WarningsAsErrors>nullable</WarningsAsErrors>


### PR DESCRIPTION
When clearing the query string on reset, only removes the Umbrella grid related query string elements. This resolves a bug that was occurring when resetting the filters/search on some listing pages.

Added extension method to UriExtensions and then call this when resetting.