### PR TITLE
Fixed bug in GetNextIntegerSequenceValueAsync

### DIFF
--- a/DataAccess/src/Umbrella.DataAccess.EntityFrameworkCore.SqlServer/Extensions/DbContextExtensions.cs
+++ b/DataAccess/src/Umbrella.DataAccess.EntityFrameworkCore.SqlServer/Extensions/DbContextExtensions.cs
@@ -40,7 +40,9 @@ public static class DbContextExtensions
 			Value = sequenceName
 		};
 
-		_ = await dbContext.Database.ExecuteSqlRawAsync("SET @result = NEXT VALUE FOR @sequenceName", new[] { parameter, sequenceNameParameter }, cancellationToken).ConfigureAwait(false);
+		string sql = $"SET @result = NEXT VALUE FOR {sequenceName}";
+
+		_ = await dbContext.Database.ExecuteSqlRawAsync(sql, new[] { parameter, sequenceNameParameter }, cancellationToken).ConfigureAwait(false);
 
 		return (int)parameter.Value;
 	}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>6.0.0-preview-0352</Version>
+		<Version>6.0.0-preview-0353</Version>
 
 		<Nullable>enable</Nullable>
 		<WarningsAsErrors>nullable</WarningsAsErrors>


### PR DESCRIPTION
Was getting error:
Microsoft.Data.SqlClient.SqlException (0x80131904): Incorrect syntax near '@sequenceName'.
So used string formatting instead of @ to substitute a value into the raw sql.